### PR TITLE
styling and content for two components: `AbstractGuidelines` and `APBMTHomepage`

### DIFF
--- a/src/app/abstract-guidelines/page.jsx
+++ b/src/app/abstract-guidelines/page.jsx
@@ -141,20 +141,20 @@ export default function AbstractGuidelines() {
                 </h4>
                 <div className="space-y-3">
                   <div className="flex justify-between items-center p-2 bg-white rounded">
-                    <span className="text-sm font-medium">Word Limit:</span>
-                    <span className="font-bold text-yellow-700">1000 words maximum</span>
+                    <span className="text-sm font-medium text-yellow-900">Word Limit:</span>
+                    <span className="font-bold text-yellow-600">1000 words maximum</span>
                   </div>
                   <div className="flex justify-between items-center p-2 bg-white rounded">
-                    <span className="text-sm font-medium">Submission:</span>
-                    <span className="font-bold text-yellow-700">Full paper + Abstract</span>
+                    <span className="text-sm font-medium text-yellow-900">Submission:</span>
+                    <span className="font-bold text-yellow-600">Full paper + Abstract</span>
                   </div>
                   <div className="flex justify-between items-center p-2 bg-white rounded">
-                    <span className="text-sm font-medium">Format:</span>
-                    <span className="font-bold text-yellow-700">Indian Pediatrics Original Article</span>
+                    <span className="text-sm font-medium text-yellow-900">Format:</span>
+                    <span className="font-bold text-yellow-600">Indian Pediatrics Original Article</span>
                   </div>
                   <div className="p-2 bg-white rounded">
                     <span className="text-sm font-medium text-yellow-800">Awards:</span>
-                    <span className="text-sm text-yellow-700 ml-2">Top 3 papers get oral presentation opportunity</span>
+                    <span className="text-sm text-yellow-600 ml-2">Top 3 papers get oral presentation opportunity</span>
                   </div>
                 </div>
               </div>
@@ -166,16 +166,16 @@ export default function AbstractGuidelines() {
                 </h4>
                 <div className="space-y-3">
                   <div className="flex justify-between items-center p-2 bg-white rounded">
-                    <span className="text-sm font-medium">Word Limit:</span>
-                    <span className="font-bold text-blue-700">250 words</span>
+                    <span className="text-sm font-medium text-blue-800">Word Limit:</span>
+                    <span className="font-bold text-blue-600">250 words</span>
                   </div>
                   <div className="flex justify-between items-center p-2 bg-white rounded">
-                    <span className="text-sm font-medium">Font:</span>
-                    <span className="font-bold text-blue-700">ARIAL, Size 12</span>
+                    <span className="text-sm font-medium text-blue-800">Font:</span>
+                    <span className="font-bold text-blue-600">ARIAL, Size 12</span>
                   </div>
                   <div className="flex justify-between items-center p-2 bg-white rounded">
-                    <span className="text-sm font-medium">Topic:</span>
-                    <span className="font-bold text-blue-700">Pediatric Infectious Diseases</span>
+                    <span className="text-sm font-medium text-blue-800">Topic:</span>
+                    <span className="font-bold text-blue-600">Pediatric Infectious Diseases</span>
                   </div>
                 </div>
               </div>
@@ -187,12 +187,12 @@ export default function AbstractGuidelines() {
                 </h4>
                 <div className="space-y-3">
                   <div className="flex justify-between items-center p-2 bg-white rounded">
-                    <span className="text-sm font-medium">Word Limit:</span>
-                    <span className="font-bold text-green-700">250 words</span>
+                    <span className="text-sm font-medium text-green-800">Word Limit:</span>
+                    <span className="font-bold text-green-600">250 words</span>
                   </div>
                   <div className="flex justify-between items-center p-2 bg-white rounded">
-                    <span className="text-sm font-medium">Font:</span>
-                    <span className="font-bold text-green-700">ARIAL, Size 12</span>
+                    <span className="text-sm font-medium text-green-800">Font:</span>
+                    <span className="font-bold text-green-600">ARIAL, Size 12</span>
                   </div>
                   <div className="p-2 bg-white rounded">
                     <span className="text-sm font-medium text-green-800">Note:</span>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -141,7 +141,7 @@ export default function APBMTHomepage() {
         <div className="max-w-7xl mx-auto px-4 text-center">
           <div className="inline-flex items-center bg-white/10 rounded-full px-4 py-2 mb-6">
             <Bell className="h-4 w-4 mr-2" />
-            <span className="text-sm font-medium">Abstract Submission Extended to July 10, 2025</span>
+            <span className="text-sm font-medium">Abstract Submission Extended to July 7th, 2025</span>
           </div>
           
           <h1 className="text-5xl font-bold mb-6">
@@ -263,7 +263,7 @@ export default function APBMTHomepage() {
           <div className="text-center mb-12">
             <h2 className="text-3xl font-bold text-gray-900 mb-4">Conference Overview</h2>
             <p className="text-lg text-gray-600">
-              Join the premier pediatric BMT conference in Asia-Pacific
+              Join National Conference Of Pediatric Infectious Diseases
             </p>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-4 gap-8">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -86,8 +86,8 @@ export default function APBMTHomepage() {
                 <Heart className="h-6 w-6 text-white" />
               </div>
               <div>
-                <h1 className="text-xl font-bold text-gray-800">APBMT 2025</h1>
-                <p className="text-xs text-gray-500">Asia-Pacific BMT Conference</p>
+                <h1 className="text-xl font-bold text-gray-800">NCPID 2025</h1>
+                <p className="text-xs text-gray-500">NATIONAL CONFERENCE OF PEDIATRIC INFECTIOUS DISEASES</p>
               </div>
             </div>
             
@@ -145,13 +145,13 @@ export default function APBMTHomepage() {
           </div>
           
           <h1 className="text-5xl font-bold mb-6">
-            APBMT 2025 Annual Conference
+            NCPID 2025 Annual Conference
           </h1>
           <p className="text-xl text-blue-100 mb-4 max-w-3xl mx-auto">
-            Asia-Pacific Blood and Marrow Transplantation Group Conference
+            NATIONAL CONFERENCE OF PEDIATRIC INFECTIOUS DISEASES
           </p>
           <p className="text-lg text-blue-200 mb-8 max-w-2xl mx-auto">
-            Advancing Pediatric BMT Research & Clinical Excellence
+            Pediatric Infectious Disease
           </p>
           
           <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-12">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -157,11 +157,11 @@ export default function APBMTHomepage() {
           <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-12">
             <div className="flex items-center text-blue-100">
               <Calendar className="h-5 w-5 mr-2" />
-              <span>March 15-17, 2025</span>
+              <span>10th to 12th October, 2025</span>
             </div>
             <div className="flex items-center text-blue-100">
               <MapPin className="h-5 w-5 mr-2" />
-              <span>Mumbai, India</span>
+              <span>Bengaluru, India</span>
             </div>
             <div className="flex items-center text-blue-100">
               <Users className="h-5 w-5 mr-2" />


### PR DESCRIPTION
This pull request updates the styling and content for two components: `AbstractGuidelines` and `APBMTHomepage`. The changes include adjustments to text colors for improved readability and updates to conference details to reflect a new event focus.

### Styling Updates in `AbstractGuidelines`

* Updated text colors for `Word Limit`, `Submission`, `Format`, and `Awards` sections to use more accessible shades (`text-yellow-900`, `text-yellow-600`, `text-blue-800`, `text-blue-600`, `text-green-800`, `text-green-600`). [[1]](diffhunk://#diff-0fed0c8f2bcfc135eefd007768a39dc2522b04d3e050ab1037d246237c6c62c8L144-R157) [[2]](diffhunk://#diff-0fed0c8f2bcfc135eefd007768a39dc2522b04d3e050ab1037d246237c6c62c8L169-R178) [[3]](diffhunk://#diff-0fed0c8f2bcfc135eefd007768a39dc2522b04d3e050ab1037d246237c6c62c8L190-R195)

### Content Updates in `APBMTHomepage`

* Changed conference name and description from "APBMT 2025" (Asia-Pacific BMT Conference) to "NCPID 2025" (National Conference of Pediatric Infectious Diseases). [[1]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL89-R90) [[2]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL144-R164) [[3]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL266-R266)
* Updated conference dates from "March 15-17, 2025" to "10th to 12th October, 2025" and location from "Mumbai, India" to "Bengaluru, India".
* Adjusted abstract submission deadline from "July 10, 2025" to "July 7th, 2025".